### PR TITLE
Fix positional parameters in queries.

### DIFF
--- a/lib/clickhouse_ecto/connection.ex
+++ b/lib/clickhouse_ecto/connection.ex
@@ -77,8 +77,8 @@ defmodule ClickhouseEcto.Connection do
       Regex.scan(~r/\?([0-9]+)/, sanitised)
       |> Enum.map( fn [_, x] -> String.to_integer(x) end)
 
-    if length(ordering) != length(params) do
-      raise "\nError: number of params received (#{length(params)}) does not match expected (#{length(ordering)})"
+    if Enum.max(ordering) != length(params) do
+      raise "\nError: number of params received (#{length(params)}) does not match expected (#{Enum.max(ordering)})"
     end
 
     ordered_params =


### PR DESCRIPTION
Placeholder for parameters must be used in the form of `?n` where n is
an integer. Instead of checking for the total number of placeholders,
the max `n` must be selected as number of expected parameters. This
fixes the issue where if you only use `?1` three times in your SQL
string, then an error is raised that 3 parameters are expected.